### PR TITLE
Update copyright notice & authors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'LOBI inhouse resources'
-copyright = '2018-2021, members of Laboratory of Brain Imaging'
-author = 'Michał Szczepanik, Bartosz Kossowski, Malwina Molendowska'
+copyright = '2018-2022, members of Laboratory of Brain Imaging'
+author = 'Bartosz Kossowski, Malwina Molendowska, Michał Szczepanik, Małgorzata Wierzba'
 
 # The short X.Y version
 version = ''
@@ -133,7 +133,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'LOBIinhouseresources.tex', 'LOBI inhouse resources Documentation',
-     'Michał Szczepanik', 'manual'),
+     'LOBI Team', 'manual'),
 ]
 
 


### PR DESCRIPTION
This is a little PR that adjusts copyright notice and author list. Detailed explanation of changes below.

- The `copyright` entry in the `docs/conf.py` file translates directly to the copyright notice at the bottom of the HTML page. I think it looks nice if it is kept up to date.
- The `author` list affects other kinds of outputs that can be produced by sphinx / readthedocs. I don't think it's reflected anywhere in the HTML output. I switched it to an alphabetic order; feel free to do something else (different order, group author, default value of 'unknown', ...).
- The `latex_document` has its own, initially hard-coded, value of author (probably because it needs to follow LaTeX rules for splitting multiple authors) which affects the title page of the auto-generated PDF. Me being listed there alone is a holdover from an auto-generated config file. Again, feel free to provide a different value than proposed.

The config fields are explained [here in Sphinx docs](https://www.sphinx-doc.org/en/master/usage/configuration.html`).

Feel free to make any further adjustments, either with the review functionality or by making additional commits to this PR.